### PR TITLE
view_only and show name changes from view

### DIFF
--- a/app/controllers/submitted_content_controller.rb
+++ b/app/controllers/submitted_content_controller.rb
@@ -4,7 +4,7 @@ class SubmittedContentController < ApplicationController
 
   include AuthorizationHelper
 
-  before_action :ensure_current_user_is_participant, only: %i[edit view submit_hyperlink folder_action]
+  before_action :ensure_current_user_is_participant, only: %i[edit show submit_hyperlink folder_action]
 
   # Validate whether a particular action is allowed by the current user or not based on the privileges
   def action_allowed?
@@ -31,18 +31,18 @@ class SubmittedContentController < ApplicationController
     # ACS We have to check if this participant has team or not
     SignUpSheet.signup_team(@assignment.id, @participant.user_id, nil) if @participant.team.nil?
     # @can_submit is the flag indicating if the user can submit or not in current stage
-    @can_submit = !params.key?(:view)
+    @can_submit = !params.key?(:view_only)
     @stage = @assignment.current_stage(SignedUpTeam.topic_id(@participant.parent_id, @participant.user_id))
   end
 
   # view is called when @assignment.submission_allowed(topic_id) is false
   # so @can_submit should be false
-  def view
+  def show
     @assignment = @participant.assignment
     # @can_submit is the flag indicating if the user can submit or not in current stage
     @can_submit = false
     @stage = @assignment.current_stage(SignedUpTeam.topic_id(@participant.parent_id, @participant.user_id))
-    redirect_to action: 'edit', id: params[:id], view: true
+    redirect_to action: 'edit', id: params[:id], view_only: true
   end
 
   # submit_hyperlink is called when a new hyperlink is added to an assignment
@@ -89,7 +89,7 @@ class SubmittedContentController < ApplicationController
                             user: @participant.name,
                             assignment_id: assignment.id,
                             operation: 'Remove Hyperlink')
-    action = (assignment.submission_allowed(topic_id) ? 'edit' : 'view')
+    action = (assignment.submission_allowed(topic_id) ? 'edit' : 'show')
     redirect_to action: action, id: @participant.id
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -491,7 +491,7 @@ Expertiza::Application.routes.draw do
       post :folder_action
       post :submit_hyperlink
       get :submit_hyperlink
-      get :view
+      get :show
     end
   end
 

--- a/spec/controllers/submitted_content_controller_spec.rb
+++ b/spec/controllers/submitted_content_controller_spec.rb
@@ -278,42 +278,42 @@ describe SubmittedContentController do
 
   let(:student1) { build_stubbed(:student, id: 21, role_id: 1) }
   let(:participant) { build(:participant, id: 1, user_id: 21) }
-  describe 'student#view' do
-    it 'student#view it' do
+  describe 'student#show' do
+    it 'student#show it' do
       allow(AssignmentParticipant).to receive(:find).and_return(participant)
       stub_current_user(student1, student1.role.name, student1.role)
       allow(participant).to receive(:name).and_return('Name')
       params = { id: 21 }
-      response = get :view, params: params
-      expect(response).to redirect_to(action: :edit, view: true, id: 21)
+      response = get :show, params: params
+      expect(response).to redirect_to(action: :edit, view_only: true, id: 21)
     end
   end
 
   let(:instructor1) { build_stubbed(:instructor, id: 21, role_id: 1) }
   let(:participant) { build(:participant, id: 1, user_id: 21) }
 
-  describe 'instructor#view' do
-    it 'instructor#view it' do
+  describe 'instructor#show' do
+    it 'instructor#show it' do
       allow(AssignmentParticipant).to receive(:find).and_return(participant)
       stub_current_user(instructor1, instructor1.role.name, instructor1.role)
       allow(participant).to receive(:name).and_return('Name')
       params = { id: 21 }
-      response = get :view, params: params
-      expect(response).to redirect_to(action: :edit, view: true, id: 21)
+      response = get :show, params: params
+      expect(response).to redirect_to(action: :edit, view_only: true, id: 21)
     end
   end
 
   let(:superadmin1) { build_stubbed(:superadmin, id: 21, role_id: 1) }
   let(:participant) { build(:participant, id: 1, user_id: 21) }
 
-  describe 'superadmin#view' do
-    it 'superadmin#view it' do
+  describe 'superadmin#show' do
+    it 'superadmin#show it' do
       allow(AssignmentParticipant).to receive(:find).and_return(participant)
       stub_current_user(superadmin1, superadmin1.role.name, superadmin1.role)
       allow(participant).to receive(:name).and_return('Name')
       params = { id: 21 }
-      response = get :view, params: params
-      expect(response).to redirect_to(action: :edit, view: true, id: 21)
+      response = get :show, params: params
+      expect(response).to redirect_to(action: :edit, view_only: true, id: 21)
     end
   end
 


### PR DESCRIPTION
Changes are made for the function view to show, which would be the convention followed by Rails.
Changes related to view variable to view_only is also made, where the function of the variable is to be a flag which indicates if the form is view or not.